### PR TITLE
Compiles under osx with golang 1.9

### DIFF
--- a/hid_darwin.go
+++ b/hid_darwin.go
@@ -30,9 +30,8 @@ import (
 	"unsafe"
 )
 
-func ioReturnToErr(ret_ C.IOReturn) error {
-	ret := uint64(ret_)
-	switch ret {
+func ioReturnToErr(ret C.IOReturn) error {
+	switch uint64(ret) {
 	case C.kIOReturnSuccess:
 		return nil
 	case C.kIOReturnError:

--- a/hid_darwin.go
+++ b/hid_darwin.go
@@ -30,7 +30,8 @@ import (
 	"unsafe"
 )
 
-func ioReturnToErr(ret C.IOReturn) error {
+func ioReturnToErr(ret_ C.IOReturn) error {
+	ret := uint64(ret_)
 	switch ret {
 	case C.kIOReturnSuccess:
 		return nil


### PR DESCRIPTION
This fixes https://github.com/boombuler/hid/issues/12

Getting an int, but constants defined as uint64. Simple type-cast lets it compile, and I get the proper error messages in manual testing on osx.