### PR TITLE
reverting fix (not needed with Xcode 9.0.1)

### DIFF
--- a/hid_darwin.go
+++ b/hid_darwin.go
@@ -31,7 +31,7 @@ import (
 )
 
 func ioReturnToErr(ret C.IOReturn) error {
-	switch uint64(ret) {
+	switch ret {
 	case C.kIOReturnSuccess:
 		return nil
 	case C.kIOReturnError:


### PR DESCRIPTION
The fix cb0427936a68ad78951eb4295d1a3d9264c1be98 actually breaks anything with the latest Xcode version (9.0.1) 
Discovered this when our CICD pipeline(https://travis-ci.org/Symantec/keymaster  forced to 1.8) was discovered broken this morning.

Seems like the original problem was with Xcode. With the fix hid compiles on 1.8.2 and 1.9.2 on MacOS. 