### PR TITLE
removing cgo flag not whitelisted in go 1.9.4

### DIFF
--- a/hid_darwin.go
+++ b/hid_darwin.go
@@ -1,7 +1,7 @@
 package hid
 
 /*
-#cgo LDFLAGS: -L . -L/usr/local/lib -framework CoreFoundation -framework IOKit -fconstant-cfstrings
+#cgo LDFLAGS: -L . -L/usr/local/lib -framework CoreFoundation -framework IOKit
 
 #include <IOKit/hid/IOHIDManager.h>
 #include <CoreFoundation/CoreFoundation.h>


### PR DESCRIPTION
With the golang 1.9.4 (and 1.8.7) update cgo flags need to be in a whilteist. "-fconstant-cfstrings" is not on that list, breaking compilation. 