### PR TITLE
Fix CF types for go 1.10, support go 1.9 and 1.10

### DIFF
--- a/hid_darwin.go
+++ b/hid_darwin.go
@@ -1,7 +1,7 @@
 package hid
 
 /*
-#cgo LDFLAGS: -L . -L/usr/local/lib -framework CoreFoundation -framework IOKit -fconstant-cfstrings
+#cgo LDFLAGS: -L . -L/usr/local/lib -framework CoreFoundation -framework IOKit
 
 #include <IOKit/hid/IOHIDManager.h>
 #include <CoreFoundation/CoreFoundation.h>
@@ -164,7 +164,7 @@ func cfstring(s string) C.CFStringRef {
 }
 
 func gostring(cfs C.CFStringRef) string {
-	if cfs == nil {
+	if cfs == nilCfStringRef {
 		return ""
 	}
 
@@ -189,7 +189,7 @@ func gostring(cfs C.CFStringRef) string {
 func getIntProp(device C.IOHIDDeviceRef, key C.CFStringRef) int32 {
 	var value int32
 	ref := C.IOHIDDeviceGetProperty(device, key)
-	if ref == nil {
+	if ref == nilCfTypeRef {
 		return 0
 	}
 	if C.CFGetTypeID(ref) != C.CFNumberGetTypeID() {
@@ -213,12 +213,17 @@ func getPath(osDev C.IOHIDDeviceRef) string {
 }
 
 func iterateDevices(action func(device C.IOHIDDeviceRef) bool) cleanupDeviceManagerFn {
-	mgr := C.IOHIDManagerCreate(C.kCFAllocatorDefault, C.kIOHIDOptionsTypeNone)
+	var mgr C.IOHIDManagerRef
+	mgr = C.IOHIDManagerCreate(C.kCFAllocatorDefault, C.kIOHIDOptionsTypeNone)
 	C.IOHIDManagerSetDeviceMatching(mgr, nil)
 	C.IOHIDManagerOpen(mgr, C.kIOHIDOptionsTypeNone)
 
-	allDevicesSet := C.IOHIDManagerCopyDevices(mgr)
-	defer C.CFRelease(C.CFTypeRef(allDevicesSet))
+	var allDevicesSet C.CFSetRef
+	allDevicesSet = C.IOHIDManagerCopyDevices(mgr)
+	if allDevicesSet == nilCfSetRef {
+		return func() {}
+	}
+	defer C.CFRelease((C.CFTypeRef)(allDevicesSet))
 	devCnt := C.CFSetGetCount(allDevicesSet)
 	allDevices := make([]unsafe.Pointer, uint64(devCnt))
 	C.CFSetGetValues(allDevicesSet, &allDevices[0])
@@ -334,7 +339,7 @@ func (dev *osxDevice) close(disconnected bool) {
 	delete(deviceCtx, dev.osDevice)
 	deviceCtxMtx.Unlock()
 	C.CFRelease(C.CFTypeRef(dev.osDevice))
-	dev.osDevice = nil
+	dev.osDevice = nilIOHIDDeviceRef
 	dev.closeDM()
 	dev.disconnected = true
 }

--- a/hid_darwin_go110.go
+++ b/hid_darwin_go110.go
@@ -1,0 +1,14 @@
+// +build go1.10,darwin
+
+package hid
+
+/*
+#include <IOKit/hid/IOHIDManager.h>
+#include <CoreFoundation/CoreFoundation.h>
+*/
+import "C"
+
+var nilCfStringRef C.CFStringRef= 0
+var nilCfTypeRef C.CFTypeRef = 0
+var nilCfSetRef C.CFSetRef = 0
+var nilIOHIDDeviceRef C.IOHIDDeviceRef = 0

--- a/hid_darwin_go19.go
+++ b/hid_darwin_go19.go
@@ -1,0 +1,14 @@
+// +build go1.9,!go1.10,darwin
+
+package hid
+
+/*
+#include <IOKit/hid/IOHIDManager.h>
+#include <CoreFoundation/CoreFoundation.h>
+ */
+import "C"
+
+var nilCfStringRef C.CFStringRef= nil
+var nilCfTypeRef C.CFTypeRef = nil
+var nilCfSetRef C.CFSetRef = nil
+var nilIOHIDDeviceRef C.IOHIDDeviceRef = nil


### PR DESCRIPTION
In Go 1.10 cgo changed how some types in CoreFoundation our represented. Instead of pointers, some types act as a uintptr. This means that we can't compare against `nil` for these, and must use `0`.

This change adds a definition for a nil type for the different CF types used, based on the version of Go that it is being built for. 

It also drops the "-fconstant-cfstrings" cgo flag, as this is not white listed after go 1.9.3, and breaks compilation.