### PR TITLE
Use lowercase lib name

### DIFF
--- a/hid_windows.go
+++ b/hid_windows.go
@@ -1,7 +1,7 @@
 package hid
 
 /*
-#cgo LDFLAGS: -lSetupapi -lhid
+#cgo LDFLAGS: -lsetupapi -lhid
 
 #ifdef __MINGW32__
 #include <ntdef.h>


### PR DESCRIPTION
Windows doesn't care but minGW under Linux does